### PR TITLE
gpkg-to-pgdump.yml: Limit trigger to activities on master branch only

### DIFF
--- a/.github/workflows/gpkg-to-pgdump.yml
+++ b/.github/workflows/gpkg-to-pgdump.yml
@@ -5,7 +5,11 @@ name: GPKG to PostgreSQL archive
 
 on:
   push:
-  pull_request:
+    branches:
+      - master
+  #pull_request:
+  #  branches:
+  #    - master
   schedule:
     - cron: '38 2 */3 * *'
   workflow_dispatch:
@@ -45,6 +49,9 @@ jobs:
         with:
           path: .git/lfs
           key: ${{ runner.os }}-lfs-${{ hashFiles('**/*.gpkg') }} # Adapt to target the type of the files committed with git lfs
+          restore-keys: |
+            ${{ runner.os }}-lfs-${{ hashFiles('**/*.gpkg') }}
+            ${{ runner.os }}-lfs-
 
       - name: Pre-run information
         if: ${{ github.event_name != 'schedule' }}
@@ -78,7 +85,7 @@ jobs:
           psql -d "$DB_NAME" -c 'CREATE EXTENSION fuzzystrmatch;'
           psql -d "$DB_NAME" -c 'CREATE EXTENSION postgis_tiger_geocoder;'
 
-      - name: Run ogr2ogr to GeoPackage files into PostGIS
+      - name: Run ogr2ogr to import GeoPackage files into PostGIS
         if: ${{ github.event_name != 'schedule' }}
         run: |
           ogr2ogr --version


### PR DESCRIPTION
Also:
- Allow the use of previous Git LFS cache even if it does not match
- Fix missing word "import" in the name "Run ogr2ogr to import
  GeoPackage files into PostGIS"

----

Hi @wkhchow and @mjourneay,

Sorry for the false alarm in #14, i.e. "All checks have failed: GPKG to PostgreSQL archive / gpkg-to-pgdump (push) Failing after 6m".  That was caused by a bug in my GitHub Actions workflow script as well as a wrong setting in my Backblaze B2 public bucket.  Hopefully both are now addressed and will be fixed with the merging of this pull request.