### PR TITLE
gpkg-to-pgdump: Upload to Amazon S3 bucket too

### DIFF
--- a/.github/workflows/gpkg-to-pgdump.yml
+++ b/.github/workflows/gpkg-to-pgdump.yml
@@ -99,6 +99,18 @@ jobs:
           stdbuf -oL pg_dump --version
           stdbuf -oL pg_dump --clean --if-exists -Fc -Z 9 -f opendrr-boundaries.dump "$DB_NAME"
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.S3_WRITER_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.S3_WRITER_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+
+      - name: Copy opendrr-boundaries.dump to the S3 bucket with the AWS CLI
+        if: ${{ github.event_name != 'schedule' }}
+        run: |
+          aws s3 sync . s3://opendrr-api-prebuilt-cache-1/boundaries/ --exclude "*" --include "opendrr-boundaries.dump" --include "opendrr-boundaries.sql" --acl bucket-owner-full-control
+
       - name: Upload to Backblaze B2
         if: ${{ github.event_name != 'schedule' }}
         env:


### PR DESCRIPTION
This PR is a prerequisite of OpenDRR/opendrr-api#116

***

This has been tested to work in the GitHub Actions test run at https://github.com/anthonyfok/boundaries/runs/2847712508?check_suite_focus=true

Both opendrr-boundaries.dump and opendrr-boundaries.sql are uploaded to the boundaries/ directory inside the `opendrr-api-prebuilt-cache-1` S3 bucket in the Sandbox.

## TODO

- [ ] Change to use new S3 bucket in "Dev" when ready.