### PR TITLE
gpkg-to-pgdump: Disable keep-cache-fresh cron schedule

### DIFF
--- a/.github/workflows/gpkg-to-pgdump.yml
+++ b/.github/workflows/gpkg-to-pgdump.yml
@@ -24,8 +24,8 @@ on:
   #pull_request:
   #  branches:
   #    - master
-  schedule:
-    - cron: '38 2 */3 * *'
+  #schedule:
+  #  - cron: '38 2 */3 * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This is to prevent GitHub from disabling the entire GitHub Actions
including push event workflow (for release assets building) altogether.

Indeed, my previous trick of trying to reduce download from Git LFS
by running a scheduled workflow thrice-weekly to keep the cache fresh
totally backfired.  According to GitHub documentation:

    Warning: To prevent unnecessary workflow runs,
    scheduled workflows may be disabled automatically. ...
    In a public repository, scheduled workflows are automatically
    disabled when no repository activity has occurred in 60 days.

See https://docs.github.com/en/actions/managing-workflow-runs/disabling-and-enabling-a-workflow